### PR TITLE
FIX: Deadlock issues with /api/v3/users

### DIFF
--- a/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
+++ b/src/main/scala/gitbucket/core/servlet/ApiAuthenticationFilter.scala
@@ -53,8 +53,9 @@ class ApiAuthenticationFilter extends Filter with AccessTokenService with Accoun
   }
 
   def doBasicAuth(auth: String, settings: SystemSettings, request: HttpServletRequest): Option[Account] = {
-    implicit val session = request.getAttribute(Keys.Request.DBSession).asInstanceOf[slick.jdbc.JdbcBackend#Session]
     val Array(username, password) = AuthUtil.decodeAuthHeader(auth).split(":", 2)
-    authenticate(settings, username, password)
+    Database() withTransaction { implicit session =>
+      authenticate(settings, username, password)
+    }
   }
 }


### PR DESCRIPTION
I've tampered a bit with the code, and found out that, when a user log-in request is handled, a new connection is created, and transmited down the pipeline (trough implicit).

Swapped that to a new transaction, and now, authentications that has side effects doesn't get deadlocked when accounts are requested. I'm testing this changes on my server, and for now, everything works as expected.